### PR TITLE
Fixed the VP table for world 1xx to include the 2VP for each complete set

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,6 +274,9 @@
 						<tr><th># of delivered goods of a single type</th><th>1</th><th>2</th><th>3</th><th>4</th><th>5+</th></tr>
 						<tr><th>victory points (VP)</th><td>5 VP</td><td>9 VP</td><td>12 VP</td><td>14 VP</td><td>15 VP</td></tr>
 					</table>
+                                        <p>Additionally, the player gets 2 VP for each set containing all 5 different types of goods.</p>
+
+           
 				</div>
 			{{/1.I}}
 		{{/1}}


### PR DESCRIPTION
Simply added a line below the table.
