### PR TITLE
Fixed an error that assigns the wrong priority to staggered income.

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 				{{/2.III}}
 			{{/2}}
 			{{#3}}
-				<p>Depending on the 3 modules take the appropriate privileges. 4♟ or 5 stock companies: Take 2 cards of each privilege. 3♟: First take 1 card of each privilege, shuffle them and remove half of them from the game. Then, add 1 card of each privelige to the remaining half. 2♟: Take 1 card of each privilege.</p>
+				<p>Depending on the 3 modules take the appropriate privileges. 4♟ or 5 stock companies: Take 2 cards of each privilege. 3♟: First take 1 card of each privilege, shuffle them and remove half of them from the game. Then, add 1 card of each privilege to the remaining half. 2♟: Take 1 card of each privilege.</p>
 				<p>Shuffle the privileges separated by card backs I, II, III and place them in a single stack, so that the cards with the back I are on top, the cards with the back III are at the bottom.</p>
 				<p>Place the price token next to the map. Draw 1 privilege per player and place them in a face-up row to the right of the price token, so that the minimal bid for each privilege is $20.</p>
 				{{^3.III}}<p>Depending on the # of players place the matching player order cards and 1 resident of each player next to the map.</p>{{/3.III}}
@@ -302,7 +302,7 @@
 					<ol>
 						<li>The attacker rolls 1 die for each attacking army. For each hit he removes 1 defending army (excess hits are forfeited).</li>
 						<li>Only if the defender suffers losses, he rolls 1 die for each of his removed armies. For each hit he removes 1 attacking army (excess hits are forfeited).</li>
-						<li>If all defending armies are removed and at least 1 attacking army survives, the attacker conquers the tile and exchanges 1 resident into 1 settlement. If at least 1 defending army sufvives, the attacker retreats all surviving armies into any adjacent areas under his control (in which are actual no fights).</li>
+						<li>If all defending armies are removed and at least 1 attacking army survives, the attacker conquers the tile and exchanges 1 resident into 1 settlement. If at least 1 defending army survives, the attacker retreats all surviving armies into any adjacent areas under his control (in which are actual no fights).</li>
 					</ol>
 				</div>
 				<div class="note col-md-4 col-xs-6">
@@ -365,7 +365,7 @@
 					</table>
 					<p>Additionally 3 VP for each set consisting of 1 city, 1 grassland, 1 field, 1 forest, 1 mountain (no desert).</p>
 					<h2>Example Final Scoring:</h2>
-					<p>Anne scores a total of 58 VP: 27 (5 vities, 4 mountains) + 22 (4 grasslands, 2 forests, 5 fields) + 3 (3 deserts) + 6 (2 sets of all terrain types excluding desert).</p>
+					<p>Anne scores a total of 58 VP: 27 (5 cities, 4 mountains) + 22 (4 grasslands, 2 forests, 5 fields) + 3 (3 deserts) + 6 (2 sets of all terrain types excluding desert).</p>
 				</div>
 			{{/6.I}}
 
@@ -397,7 +397,7 @@
 					<tr><td>max. $50</td><td>max. $50</td><td>max. $45</td><td>max. $40</td><td>max. $35</td><td>max. $30</td></tr>
 				</table>
 				<p>In case of a tie all concerned players get the calculated income up to the stated maximum.</p>
-				<p><b>Example Income:</b> Camilled has majorities for grasslands (2 tiles) and fields (% tiles). She gets a total of $80 = $20 (base income for the capital) + $20 (for 2 grasslands) + $40 (maximum for 4 fields). The additional field only secures her majority, but does not increase her income!</p>
+				<p><b>Example Income:</b> Camille has majorities for grasslands (2 tiles) and fields (% tiles). She gets a total of $80 = $20 (base income for the capital) + $20 (for 2 grasslands) + $40 (maximum for 4 fields). The additional field only secures her majority, but does not increase her income!</p>
 			</div>
 		{{/7.II}}
 		{{#7.III}}
@@ -458,7 +458,7 @@
 		{{/8}}
 		{{#9.I}}
 			<div class="note col-md-12 col-xs-12">
-				<p><b>Calculation of Dividends:</b> The company pays $1 dividends for each full $10 income to each share ($2 ot the president's share)</p>
+				<p><b>Calculation of Dividends:</b> The company pays $1 dividends for each full $10 income to each share ($2 to the president's share)</p>
 				<p><b>Example:</b> The green company gets an income of $68. Thus, it pays $6 dividends. Camille is the only player owning 5 shares and gets $30. The company gets the remaining $38 for their company assets.</p>
 			</div>
 		{{/9.I}}
@@ -579,7 +579,7 @@
 			{{#9.II}}
 				<p>The stock company order for the 1st business round (BR) is determined in <b>reverse</b> order of establishment. If stock companies are only established in later share rounds (SR), just for once they are first in stock company order in the next BR, if necessary in reverse order of establishment!</p>
 			{{/9.II}}
-			<p>After all players have taken one complete turn, the player order is readjusted. For the 2nd turn set the new player order by lpacing the residents on the spaces of the 2nd starting card and starting with the 3rd r ound separately on the face down scoring cards.</p>
+			<p>After all players have taken one complete turn, the player order is readjusted. For the 2nd turn set the new player order by placing the residents on the spaces of the 2nd starting card and starting with the 3rd round separately on the face down scoring cards.</p>
 			<p>As long as the players do not have victory points (VP), simply reverse the player order of the former turn. As soon as the players have VP, the new player order is determined according to VP from few to most. The player with the fewest VP is new starting player, the player with most VP is last. In case of a tie reverse the player order of all concerned players of the former turn.</p>
 			{{#3.II}}<p>Starting with the 2nd round the income is taxed according to the money, but the player order according to VP. In case of a tie for highest income, the player must pay 20%, whose turn is now earlier in player order. In case of a tie for lowest income, the player pays no taxes, whose turn is now later in the player order.</p>{{/3.II}}
 		{{/7.I}}
@@ -600,7 +600,7 @@
 					{{#9.I}}{{#3.II}}<p>Starting with the 2nd round the income is taxed according to the amount, but the stock company order according to the actual share value.</p>{{/3.II}}{{/9.I}}
 				{{/9.III}}
 				{{#9.III}}
-					<p>At the start of the game the turn order is randomly determined. Starting with the 2nd round determine the player order according to the income of the ormer round, from low to high. In case of a tie simply reverse the player order of the concerned players.</p>
+					<p>At the start of the game the turn order is randomly determined. Starting with the 2nd round determine the player order according to the income of the former round, from low to high. In case of a tie simply reverse the player order of the concerned players.</p>
 				{{/9.III}}
 			</div>
 		</div>
@@ -634,7 +634,7 @@
 		<div class="row section">
 			<div class="col-md-2 col-xs-2"><h1>Phase 3 B: Stock Dealing</h1></div>
 			<div class="col-md-10 col-xs-10">
-				<p>The player may buy any number of shares of the other players from the bank for the actual share value, if these were already sole in a former round to the bank (if their dark side is face up). The player cannot sell these shares again!</p>
+				<p>The player may buy any number of shares of the other players from the bank for the actual share value, if these were already sold in a former round to the bank (if their dark side is face up). The player cannot sell these shares again!</p>
 				<p>Additionally, the player may sell exactly 1 of his shares to the bank during his turn. He places the share for now with the light side face up into the bank and gets money according to the actual share value (this money is not considered as income!). Then, the share value drops by $10. The player cannot sell his president's share! The player may conduct this <b>sale during his complete turn</b> to get missing money for one of his actions!</p>
 			</div>
 		</div>
@@ -696,21 +696,21 @@
 			{{^4.III}}{{#2}}
 				{{#3}}<p>If the attacker neutralizes an opposing city, 1 existing factory there is destroyed. If the attacker later conquers the city with 1 additional resident, he gets the remaining factories there.</p>{{/3}}
 				{{#8}}<p>There are no fights in cities, so any number of players may have their own trading houses there. If the player conquers a land tile, he also conquers an existing plant. If the land tile is neutralized, the plant remains abandoned for now.</p>{{/8}}
-				{{#4.II}}{{#9}}<p>If the attacking stock company conquers an opposing capital by immediately moving 1 additional active resident onto the neutralized city, it also conquers all other tiles of the defender by exchanging the armies with its own.{{#2.III}} If the attacking stock company neutralizes the last capital of the defender, it may conquer that capital immediately after the fight by moving 1 additional active resident onto the neutralized city.{{/2.III}} If the attacker only neutralizes the capital, the defender loses all of his tiles without the attacker conquering them. Afterwards the players lose all shares of the defeated stock company without substituion. The stock company starts anew and may be established again by the players in the next share round (SR).{{#1.1}} Place all delivered goods of that company separately next to the map, as they still count for the game end!{{/1.1}}</p>{{/9}}{{/4.II}}
+				{{#4.II}}{{#9}}<p>If the attacking stock company conquers an opposing capital by immediately moving 1 additional active resident onto the neutralized city, it also conquers all other tiles of the defender by exchanging the armies with its own.{{#2.III}} If the attacking stock company neutralizes the last capital of the defender, it may conquer that capital immediately after the fight by moving 1 additional active resident onto the neutralized city.{{/2.III}} If the attacker only neutralizes the capital, the defender loses all of his tiles without the attacker conquering them. Afterwards the players lose all shares of the defeated stock company without substitution. The stock company starts anew and may be established again by the players in the next share round (SR).{{#1.1}} Place all delivered goods of that company separately next to the map, as they still count for the game end!{{/1.1}}</p>{{/9}}{{/4.II}}
 			{{/2}}{{/4.III}}
 			{{#4.III}}
 				{{#3}}<p>If the attacker neutralizes an opposing city, 1 existing factory there is destroyed. IF the attacker later conquers the city with 1 additional resident, he gets the remaining factories there.</p>{{/3}}
 				{{#8}}<p>There are no fights in cities, so any number of players may have their own trading houses there. If the player conquers a land tile, he also conquers an existing plant. If the land tile is neutralized, the plant remains abandoned for now.</p>{{/8}}
-				{{#9}}<p>If the attacking stock company conquers an opposing capital by immediately moving 1 additional active resident onto the neutralized city, it also conquers all other tiles of the defender by exchanging the armies with its own. If the attacker only neutralizes the capital, the defender loses all of his tiles without the attacker conquering them. Afterwards the players lose all shares of the defeated stock company without substituion. The stock company starts anew and may be established again by the players in the next share round (SR).{{#1.1}} Place all delivered goods of that company separately next to the map, as they still count for the game end!{{/1.1}}</p>{{/9}}
+				{{#9}}<p>If the attacking stock company conquers an opposing capital by immediately moving 1 additional active resident onto the neutralized city, it also conquers all other tiles of the defender by exchanging the armies with its own. If the attacker only neutralizes the capital, the defender loses all of his tiles without the attacker conquering them. Afterwards the players lose all shares of the defeated stock company without substitution. The stock company starts anew and may be established again by the players in the next share round (SR).{{#1.1}} Place all delivered goods of that company separately next to the map, as they still count for the game end!{{/1.1}}</p>{{/9}}
 			{{/4.III}}
 		{{/4}}
 		{{#5.I}}<p>The player may explore and adjacent unknown space with 1 active resident. He places that resident back into his storage (except if it explores water, instead it is placed exhausted on the starting tile).</p>{{/5.I}}
 		{{#5.II}}
-			{{#2}}<p>The player may explore any number of adjacent unknown spaces with 1 active resident. He places that resident back into his storage (excpet if it explores only water, instead it is placed exhausted on the starting tile).</p>{{/2}}
+			{{#2}}<p>The player may explore any number of adjacent unknown spaces with 1 active resident. He places that resident back into his storage (except if it explores only water, instead it is placed exhausted on the starting tile).</p>{{/2}}
 			{{^2}}{{#4}}<p>The player may explore and adjacent unknown space with 1 active resident. He places that resident back into his storage (except if it explores water, instead it is placed exhausted on the starting tile).</p>{{/4}}{{/2}}
 			{{^2}}{{^4}}<p>The player may explore an adjacent unknown space with 1 active resident. Afterwards the resident is exhausted on the starting tile.</p>{{/4}}{{/2}}
 		{{/5.II}}
-		{{#5.III}}<p>The player may explore any number of adjacent unknown spaces with 1 active resident. He places that resident back into his storage (except if it explores only water, instead it is placed exhauted on the starting tile).</p>{{/5.III}}
+		{{#5.III}}<p>The player may explore any number of adjacent unknown spaces with 1 active resident. He places that resident back into his storage (except if it explores only water, instead it is placed exhausted on the starting tile).</p>{{/5.III}}
 		{{#5}}
 			<p><b>Exploring:</b> After choosing the destination space, the player places the explorer tiles next to the following stacks, until he placed all 6 tiles.</p>
 			<ol>
@@ -789,11 +789,11 @@
 			{{^1.III}}<p>
 				The goal of the player is to deliver the goods to a city, which has demand for this type of good. Each city takes only 1 good for each listed goods type.
 				{{#1.I}}The player places the delivered goods face up in front of himself and covers the matching spaces on the cities with covering tokens.{{/1.I}}
-				{{#1.II}}The player places the goods face up below the goods price board in the order he dlivered them during his turn and covers the matching spaces on the cities with covering tokens. IF the player delivers 2 goods to the same city, he decides in which order he places them below the goods price board.{{/1.II}}
+				{{#1.II}}The player places the goods face up below the goods price board in the order he delivered them during his turn and covers the matching spaces on the cities with covering tokens. IF the player delivers 2 goods to the same city, he decides in which order he places them below the goods price board.{{/1.II}}
 			</p>{{/1.III}}
 			{{^residents}}<p>The player may buy additional MP for his transport trolley, see the table <b>Prices for Additional Movement Points (MP)</b>.</p>{{/residents}}
 			{{#4}}
-				<p>The player may move his transport trolley on all tiles, even on opposing tiles. He gets 1 additional MP, if the transport trolleey starts the movement on one of his tiles. If the transport trolley moves onto opposing tiles for the first time during this phase, he needs 1 additional MP for each opponent (if it starts on an opposing tile or continues to move onto more tiles of the same opponent, no further additional MPs are needed).</p>
+				<p>The player may move his transport trolley on all tiles, even on opposing tiles. He gets 1 additional MP, if the transport trolley starts the movement on one of his tiles. If the transport trolley moves onto opposing tiles for the first time during this phase, he needs 1 additional MP for each opponent (if it starts on an opposing tile or continues to move onto more tiles of the same opponent, no further additional MPs are needed).</p>
 				{{#8}}{{^8.III}}<p>The cities are neutral and no player is controlling them. Each player may move onto a city for 1 MP.</p>{{/8.III}}{{/8}}
 				<p>If the transport trolley moves onto an opposing tile with loaded residents, the player must unload them for the fight. The player cannot load exhausted residents on an opposing tile. {{#2}}After the transport trolley finishes its movement, a fight follows immediately.{{/2}}</p>
 			{{/4}}
@@ -848,7 +848,7 @@
 				{{#3}}{{^3.III}}<p>If the attacker neutralizes an opposing city, 1 existing factory there is destroyed. If the attacker later conquers the city with 1 additional resident, he gets the remaining factories there.</p>{{/3.III}}{{/3}}
 				{{#8}}{{^8.III}}<p>There are no fights in cities, so any number of players may have their own trading houses there. If the player conquers a land tile, he also conquers an existing plant. If the land tile is neutralized, the plant remains abandoned for now.</p>{{/8.III}}{{/8}}
 			{{/4.III}}{{/4}}
-			{{#4.II}}{{#9.I}}<p>If the attacking stock company conquers an opposing capital, it also conquers all other tiles of the defender and exchanges the armies with its own. If it only neutralizes the opposing capital, the defender loses all of his tiles without the attacker conquering them. Afterwards the players lose all shares of the defated stock company without substitution. The stock company starts anew and may be established again by the players in the next share round (SR).</p>{{/9.I}}{{/4.II}}
+			{{#4.II}}{{#9.I}}<p>If the attacking stock company conquers an opposing capital, it also conquers all other tiles of the defender and exchanges the armies with its own. If it only neutralizes the opposing capital, the defender loses all of his tiles without the attacker conquering them. Afterwards the players lose all shares of the defeated stock company without substitution. The stock company starts anew and may be established again by the players in the next share round (SR).</p>{{/9.I}}{{/4.II}}
 		{{/2}}
 	{{/capture}}
 	{{#hascapture}}
@@ -891,7 +891,7 @@
 			{{^2}}{{#4}}<p>If the player removes his settlement and then the tile is completely empty, the next player placing a new first settlement on that tile also takes 1 income token.</p>{{/4}}{{/2}}
 			{{^2}}{{^4}}{{#7.I}}<p>If the player removes his settlement and then the tile is completely empty, the next player placing a new first settlement on that tile also takes 1 income token.</p>{{/7.I}}{{/4}}{{/2}}
 		{{/5.II}}
-		{{#6.II}}<p>The player gets $20 base income for his capital, plus $10 for each additional city he connected. Furthermore each of his connected cities gives the player money for 1 land tile of each type (except deserts): he gets $5 for grassland, field & forest, $10 for mountian, plus a bonus of $10 for each set containing 1 city, 1 grassland, 1 field, 1 forest, 1 mountain (no desert), see the example <b>Income</b>.</p>{{/6.II}}
+		{{#6.II}}<p>The player gets $20 base income for his capital, plus $10 for each additional city he connected. Furthermore each of his connected cities gives the player money for 1 land tile of each type (except deserts): he gets $5 for grassland, field & forest, $10 for mountain, plus a bonus of $10 for each set containing 1 city, 1 grassland, 1 field, 1 forest, 1 mountain (no desert), see the example <b>Income</b>.</p>{{/6.II}}
 		{{#7.II}}<p>The player gets $20 base income for the capital, plus income for the majorities as stated above, see table and example <b>Income</b>.</p>{{/7.II}}
 		{{#8.II}}
 			<p>{{^1}}During this phase, the player gets 1 matching good for each of his plants from the general storage.{{/1}}{{#1}}The player may sell goods already delivered to his trading houses.{{/1}} He may sell {{^4}}1 good{{/4}}{{#4}}2 goods{{/4}} to each of his trading houses{{^4}} (up to 2 goods to the headquarters in his capital){{/4}}. {{^1}}Afterwards, he places the sold goods back into the general storage.{{/1}}{{#1}}Afterwards, the goods remain on the trading houses.{{/1}}</p>
@@ -927,7 +927,7 @@
 				{{#2}}<p>If the company removes its settlement and then the tile is completely empty, the next company placing a new first settlement on that tile also takes 1 income token.</p>{{/2}}
 				{{^2}}{{#4}}<p>If the company removes its settlement and then the tile is completely empty, the next company placing a new first settlement on that tile also takes 1 income token.</p>{{/4}}{{/2}}
 			{{/5.I}}
-			{{#6.I}}<p>The company gets $20 base income for its capital, plus $10 for each additional city it connected. Furthermore each of its connected cities gives the company money for 1 land tile of each type (except deserts): it gets $5 for grassland, field & forest, $10 for mountian, plus a bonus of $10 for each set containing 1 city, 1 grassland, 1 field, 1 forest, 1 mountain (no desert), see the example <b>Income</b>.</p>{{/6.I}}
+			{{#6.I}}<p>The company gets $20 base income for its capital, plus $10 for each additional city it connected. Furthermore each of its connected cities gives the company money for 1 land tile of each type (except deserts): it gets $5 for grassland, field & forest, $10 for mountain, plus a bonus of $10 for each set containing 1 city, 1 grassland, 1 field, 1 forest, 1 mountain (no desert), see the example <b>Income</b>.</p>{{/6.I}}
 			{{#7.I}}<p>The company gets $20 base income for the capital, plus income for the majorities as stated above, see table and example <b>Income</b>.</p>{{/7.I}}
 			{{#8.I}}
 				<p>{{^1}}The company may sell goods already produced in its plants.{{/1}}{{#1}}The company may sell goods already delivered to its trading houses.{{/1}} It may sell 1 good to each of its trading houses (up to 2 goods to the headquarters in its capital). {{^1}}Afterwards, the goods remain in front of the company card.{{/1}}{{#1}}Afterwards, the goods remain on the trading houses.{{/1}}</p>
@@ -1105,7 +1105,7 @@
 		{{/8.I}}
 		{{#9}}
 			{{#9.I}}
-				<p>The players determine their wealth: EAch player counts his money and adds the actual share value of each of his own shares according to the share value board to his money (the president's share counts twice). {{#7.III}}The share value of each share is $1 higher for each VP of the stock company.{{/7.III}}</p>
+				<p>The players determine their wealth: Each player counts his money and adds the actual share value of each of his own shares according to the share value board to his money (the president's share counts twice). {{#7.III}}The share value of each share is $1 higher for each VP of the stock company.{{/7.III}}</p>
 				<p>The player with the biggest wealth wins the game! In case of a tie, all tied players share the victory.</p>
 			{{/9.I}}
 			{{^9.I}}

--- a/index.html
+++ b/index.html
@@ -1349,7 +1349,7 @@
 				'residents': false,
 				'map': {'priority': 1, 'value': 1},
 				'order': {'priority': 4, 'clockwise': true},
-				'money': {'priority': 4, 'increasing': true},
+				'money': {'priority': 3, 'increasing': true},
 				'parts': {'24': 6, '21': 1, '25': 30},
 			},
 			'III': {


### PR DESCRIPTION
Fixed an error that assigns the wrong priority to staggered income for 5.II. It's incorrect in the rulebook, but correct in the book of worlds. This is per FF's comments during the postmortem of the PBF game of 456 on boardgamegeek.
