### PR TITLE
Index.html: remove stray blank cell and fix a blank game-end condition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1028,9 +1028,9 @@
 					{{/4}}
 				{{/residents}}
 			{{/2.I}}
-			{{#3.1}}
+			{{#3.I}}
 				<p>The game ends at the end of the round, after a total of at least 20 factories stand in the cities.</p>
-			{{/3.1}}
+			{{/3.I}}
 			{{#4.I}}
 				<p>The game ends immediately after the end of the active player's turn, if the active player:</p>
 				<ol>

--- a/index.html
+++ b/index.html
@@ -509,7 +509,7 @@
 					<h2>Income:</h2>
 					<p>The company gets the # of tiles x $10 for each majority, up to the stated maximum.</p>
 					<table>
-						<tr><th></th><th><span class="city bigicon"></span></th><th><span class="grass bigicon"></span></th><th><span class="forest bigicon"></span></th><th><span class="grain bigicon"></span></th><th><span class="mountain bigicon"></span></th><th><span class="desert bigicon"></th></tr>
+						<tr><th><span class="city bigicon"></span></th><th><span class="grass bigicon"></span></th><th><span class="forest bigicon"></span></th><th><span class="grain bigicon"></span></th><th><span class="mountain bigicon"></span></th><th><span class="desert bigicon"></th></tr>
 						<tr><td>max. $50</td><td>max. $50</td><td>max. $45</td><td>max. $40</td><td>max. $35</td><td>max. $30</td></tr>
 					</table>
 					<p>In case of a tie all concerned companies get the calculated income up to the stated maximum.</p>


### PR DESCRIPTION
There was a stray blank cell in the max-income table for "Majorities Income".  Cell removed. 

Also, corrected a typo that prevented the display of the game-end condition for 3.I.
