### PR TITLE
Cargo upgrade for 1.III diff

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
 				<h2>Prices for Upgrades</h2>
 				<table>
 					<tr><th>4, 5, 7 MP</th><td>each {{#1.III}}{{#residents}}$30{{/residents}}{{^residents}}$50{{/residents}}{{/1.III}}{{^1.III}}$50{{/1.III}}</td></tr>
-					<tr><th>2 cargo holds</th><td>$80</td></tr>
+					<tr><th>2 cargo holds</th><td>{{#1.III}}$40{{/1.III}}{{^1.III}}$80{{/1.III}}</td></tr>
 				</table>
 			</div>
 			{{^residents}}


### PR DESCRIPTION
Rule in page 10 for 1.III has a different price for the upgrade of MP and 2 cargo holds

Didn't really test it, I'm more of a backend developer. Looks consistent with the template language though. Hope it helps!
