### PR TITLE
Fixed 3.III text for majorities

### DIFF
--- a/index.html
+++ b/index.html
@@ -965,7 +965,7 @@
 			{{#4.I}}<p>Award VP to a player when they conquer a free city from the stacks set aside on the majority board (3 for the first free city, 4 for the second, etc).</p>{{/4.I}}
 			{{#5.I}}<p>Award 5VP from the stack set aside on the corresponding column of the majority board to the first player to explore each of the 6 terrain types (no water).</p>{{/5.I}}
 			{{#6.I}}<p>Award 5 VP from the stack set aside on the corresponding column of the majority board to the first player to connect one of the 6 terrain types (no water) with his roads a third time.</p>{{/6.I}}
-			{{#7.I}}<p>Award 10 VP to the first player to control 2 of each terrain type (no water). Award 20 VP to the first player to control 2 of each terrain type (no water).</p>{{/7.I}}
+			{{#7.I}}<p>Award 10 VP to the first player to control 1 of each terrain type (no water). Award 20 VP to the first player to control 2 of each terrain type (no water).</p>{{/7.I}}
 			{{#8.I}}<p>Award 5 VP from the stack set aside for this purpose to the first player owning 3 plants of a good type.</p>{{/8.I}}
 			{{#9.I}}
 				{{#1.II}}<p>Award $50 to the first stock company delivering one of the good types a second time from the stack set aside for this purpose.</p>{{/1.II}}


### PR DESCRIPTION
Checked in both the rule book and the book of worlds. It's the same rule, but it's more explicit on the rule book.
It would not make much sense in the current wording.
Again, not tested, but the change is only character!
