### PR TITLE
Fixed cases for city layout rules in games that are not Module 1.

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
 			{{#5}}<p>Place all map tiles in separate stacks in a row as follows: city, water, grassland, forest, field, mountain and desert. {{^1.III}}Lay out the cities in a numerical ascending stack - lowest numbered city on top, city "10" on bottom.{{^8}} Place 4 goods onto each city, matching the small circular symbol.{{/8}}{{/1.III}}</p>{{/5}}
 			<p>
 				Lay out the map {{map.value}}.
-				{{^1.III}}Display cities with their goods side atop. {{#8}}The cities remain empty of goods.{{/8}}{{/1.III}}
+				{{#1}}{{^1.III}}Display cities with their goods side atop. {{#8}}The cities remain empty of goods.{{/8}}{{/1.III}}{{/1}}
 				{{#8}}
 					{{^8.III}}
 						Display land and water tiles with the goods side atop.


### PR DESCRIPTION
Someone with more familiarity with the token system should double-check this one. Basically, it was saying to layout the cities with the goods side up for all games. The world I caught it on was 358.

Thanks.
