### PR TITLE
Fixed a typo, but mainly changed the scoring rule for 9.III.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1225,9 +1225,12 @@
 				<p>The players determine their wealth: Each player counts his money and adds the actual share value of each of his own shares according to the share value board to his money (the president's share counts twice). {{#7.III}}The share value of each share is $1 higher for each VP of the stock company.{{/7.III}}</p>
 				<p>The player with the biggest wealth wins the game! In case of a tie, all tied players share the victory.</p>
 			{{/9.I}}
-			{{^9.I}}
+			{{#9.II}}
 				<p>The players determine the victory points (VP) of the 5 stock companies.</p> 
-			{{/9.I}}
+			{{/9.II}}
+			{{#9.III}}
+				<p>The players determine the victory points (VP) of the stock companies.</p> 
+			{{/9.III}}
 			{{#1.I}}
 				<p>The companies score victory points (VP) for the delivered goods, see left for the table <b>Victory Points (VP)</b>.</p>
 			{{/1.I}}
@@ -1251,7 +1254,7 @@
 				<p>The companies have earned vp in 3 scoring rounds during the game.</p>
 			{{/7.I}}
 			{{#8.I}}
-				<p>The companys take the goods {{#1}}on top of their trading houses{{/1}}{{^1}}in front of the company board{{/1}} and may score {{#4}}2 goods{{/4}}{{^4}}1 good{{/4}} for each of their trading houses{{^4}} (up to 2 goods for the headquarters in his capital){{/4}}. The company gets victory points (VP) for all scored goods, see the table and example <b>Final Scoring</b>. Before scoring the company may exchange goods in a ratio of 2:1 into different goods types, to get more valuable sets.</p>
+				<p>The companies take the goods {{#1}}on top of their trading houses{{/1}}{{^1}}in front of the company board{{/1}} and may score {{#4}}2 goods{{/4}}{{^4}}1 good{{/4}} for each of their trading houses{{^4}} (up to 2 goods for the headquarters in his capital){{/4}}. The company gets victory points (VP) for all scored goods, see the table and example <b>Final Scoring</b>. Before scoring, the company may exchange goods in a ratio of 2:1 into different goods types, to get more valuable sets.</p>
 			{{/8.I}}
 			{{#7.III}}
 				<p>The companies get additional victory points (VP) for majorities during the final scoring, see table and example of the <b>Final Scoring</b>.</p>


### PR DESCRIPTION
The original (and the BoW) mention 5 stock companies, which is impossible with xx9 games.
