### PR TITLE
Fix settlement logic in parts list.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1598,7 +1598,7 @@
 				'parts': {'2': 48, '3': 30, '10': 5, '11': 5, '12': 10, '15g': 1, '33': 1},
 				'before_render': function(params, module) {
 					if(!params.residents) {
-						if(params.world[1] == '9') {
+						if(params.world[0] == '9') {
 							module['parts']['13s'] = 15;
 						} else {
 							module['parts']['13p'] = 20;
@@ -1614,7 +1614,7 @@
 				'parts': {'10': 5, '11': 5, '12': 10, '33': 1},
 				'before_render': function(params, module) {
 					if(!params.residents) {
-						if(params.world[1] == '9') {
+						if(params.world[0] == '9' || params.world[1] == '9') {
 							module['parts']['13s'] = 15;
 						} else {
 							module['parts']['13p'] = 20;


### PR DESCRIPTION
While working on a full version of the rules, I noticed that my residents/settlements table amounts did not match the parts list in some cases where the parts list mentions settlements, e.g., world 915 (where the player settlement count of 20 appears instead of the stock company settlement count of 15).

This appears to be an error in the logic used to add the settlements to the parts list, which always referred to params.world[1], instead of 0 or both indices where appropriate.
