### PR TITLE
Fix cargo hold logic when there's nothing to transport (e.g. #291).

### DIFF
--- a/index.html
+++ b/index.html
@@ -1016,8 +1016,13 @@
 <script id="template-phase3efgh" type="x-tmpl-mustache">
 	{{#capture}}
 		{{#1}}
-			{{^1.III}}<p>The {{agent}} may transport 1 good of any type or up to 2 of {{fowns}} exhausted residents per cargo hold. He may load and unload the transport trolley any number of times. If he unloads goods on a land tile or a city, which has no demand for these goods{{#8}}{{^8.III}} (or without one of {{fowns}} trading houses){{/8.III}}{{/8}}, the goods remain there until any {{owner}} loads them again onto {{own}} transport trolley.</p>{{/1.III}}
-			{{#1.III}}<p>The {{agent}} may transport {{#8}}{{^8.III}}1 good of any type or {{/8.III}}{{/8}}up to 2 of {{fowns}} exhausted residents per cargo hold. He may load and unload the transport trolley any number of times.{{#8}}{{^8.III}}If he unloads goods on a land tile or a city, without one of {{fowns}} trading houses, the goods remain there until any {{owner}} loads them again onto {{owns}} transport trolley.{{/8.III}}{{/8}}</p>{{/1.III}}
+			{{^1.III}}
+				<p>The {{agent}} may transport 1 good of any type or up to 2 of {{fowns}} exhausted residents per cargo hold. He may load and unload the transport trolley any number of times. If he unloads goods on a land tile or a city, which has no demand for these goods{{#8}}{{^8.III}} (or without one of {{fowns}} trading houses){{/8.III}}{{/8}}, the goods remain there until any {{owner}} loads them again onto {{own}} transport trolley.</p>
+			{{/1.III}}
+			{{#1.III}}
+				{{#residents}}<p>The {{agent}} may transport {{#8}}{{^8.III}}1 good of any type or {{/8.III}}{{/8}}up to 2 of {{fowns}} exhausted residents per cargo hold. He may load and unload the transport trolley any number of times.{{#8}}{{^8.III}}If he unloads goods on a land tile or a city, without one of {{fowns}} trading houses, the goods remain there until any {{owner}} loads them again onto {{owns}} transport trolley.{{/8.III}}{{/8}}</p>{{/residents}}
+				{{^residents}}{{#8}}{{^8.III}}<p>The {{agent}} may transport 1 good of any type per cargo hold. He may load and unload the transport trolley any number of times.  If he unloads goods on a land tile or a city, without one of {{fowns}} trading houses, the goods remain there until any {{owner}} loads them again onto {{owns}} transport trolley.</p>{{/8.III}}{{/8}}{{/residents}}
+			{{/1.III}}
 			<p>The {{agent}} needs 1 MP to move {{fowns}} transport trolley from tile to tile; but he needs 2 MP for the movement from any tile up on each mountain.{{#residents}}{{^4}} The transport trolley with loaded residents may move through tiles without settlements of the {{owner}}, which are empty or have opposing settlements and residents.{{/4}} If the {{agent}} unloads residents on a tile without 1 of {{fowns}} settlements, 1 resident turns into 1 settlement.{{/residents}}</p>
 			{{#6}}
 				<p>The {{agent}} needs 0.5 MP per road when moving {{fowns}} transport trolley on {{owns}} roads.</p>


### PR DESCRIPTION
There are no residents in world 291, but the trolley phase reads "The president may transport up to 2 of the company's exhausted residents per cargo hold. He may load and unload the transport trolley any number of times."  

The change handles this situation by omitting the statement, without disturbing the logic for 8.  (It may therefore handle more cases than actually occur.)